### PR TITLE
Add Nix (the file manager) support

### DIFF
--- a/arch2appimage.py
+++ b/arch2appimage.py
@@ -223,7 +223,8 @@ while True:
                 utils.rm("download")
 
 
-appimagetool = os.path.join(RES_DIR, "appimagetool")
+# appimagetool = os.path.join(RES_DIR, "appimagetool")
+appimagetool = "appimagetool"
 
 if utils.user_confirm("Would you like to download the \
 latest AppImageTool? If you select No the existing one will be used."):
@@ -235,7 +236,7 @@ while True:
     if not os.path.exists(OUT_DIR):
         os.mkdir(OUT_DIR)
 
-    cmd = f"./{appimagetool} -n {APP_DIR} {OUT_DIR}/{main_pkg}-{ARCH}.AppImage"
+    cmd = f"{appimagetool} -n {APP_DIR} {OUT_DIR}/{main_pkg}-{ARCH}.AppImage"
     utils.run_cmd(cmd)
 
     time.sleep(5)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,127 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pypi-deps-db": [
+          "pypi-deps-db"
+        ]
+      },
+      "locked": {
+        "lastModified": 1654084003,
+        "narHash": "sha256-j/XrVVistvM+Ua+0tNFvO5z83isL+LBgmBi9XppxuKA=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "7e14360bde07dcae32e5e24f366c83272f52923f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "ref": "3.5.0",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1662019588,
+        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgsPy36": {
+      "locked": {
+        "lastModified": 1601475821,
+        "narHash": "sha256-7AI8j/xq5slauMGwC3Dp2K9TKDyDtBXBebeyWsE9euE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b4db68ff563895eea6aab4ff24fa04ef403dfe14",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "b4db68ff563895eea6aab4ff24fa04ef403dfe14",
+        "type": "indirect"
+      }
+    },
+    "pypi-deps-db": {
+      "inputs": {
+        "mach-nix": [
+          "mach-nix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgsPy36": "nixpkgsPy36",
+        "pypiIndex": "pypiIndex"
+      },
+      "locked": {
+        "lastModified": 1662366539,
+        "narHash": "sha256-r8/uEWJwkSRatJ9bSKdrCRA1+Dd0mRiJmX+sG3geFMU=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "9a9a8e899eb14c6d36d45e33bd80c9248ec4374a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "pypiIndex": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1662358103,
+        "narHash": "sha256-g4lfRwWmLJx1Uy57/kX5wIyIH97RKVOf1lag5nwvs0Y=",
+        "owner": "davhau",
+        "repo": "nix-pypi-fetcher",
+        "rev": "9f49092e821d843b6eafbdf9c5bce920a3febe28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "repo": "nix-pypi-fetcher",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,11 @@
         nativeBuildInputs = [
           myPython
         ];
+        buildInputs = [
+          pkgs.appimagekit
+          pkgs.zsync
+          pkgs.desktop-file-utils
+        ];
       };
     }
   );

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "This is a python script that downloads Arch Linux packages (Official/Chaotic AUR) and converts to an AppImage executable";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs-22.05";
+    nixpkgs.url = "nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
     # This section will allow us to create a python environment
@@ -13,7 +13,7 @@
       inputs.mach-nix.follows = "mach-nix";
     };
     mach-nix = {
-      url = "github:DavHau/mach-nix/3.3.0";
+      url = "github:DavHau/mach-nix/3.5.0";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
       inputs.pypi-deps-db.follows = "pypi-deps-db";
@@ -33,7 +33,7 @@
         # specify the base version of python you with to use
         python = "python39";
 
-        requirements = pkgs.readFile ./requirements.txt;
+        requirements = pkgs.lib.readFile ./requirements.txt;
       };
     in {
       devShell = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "This is a python script that downloads Arch Linux packages (Official/Chaotic AUR) and converts to an AppImage executable";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs-22.05";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    # This section will allow us to create a python environment
+    # with specific predefined python packages from PyPi
+    pypi-deps-db = {
+      url = "github:DavHau/pypi-deps-db";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.mach-nix.follows = "mach-nix";
+    };
+    mach-nix = {
+      url = "github:DavHau/mach-nix/3.3.0";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.pypi-deps-db.follows = "pypi-deps-db";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, mach-nix, ... }@attr:
+  flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+
+      # prepare mach-nix for usage
+      mach = mach-nix.lib.${system};
+      
+      # create a custom python environment
+      myPython = mach.mkPython {
+        # specify the base version of python you with to use
+        python = "python39";
+
+        requirements = pkgs.readFile ./requirements.txt;
+      };
+    in {
+      devShell = pkgs.mkShell {
+        nativeBuildInputs = [
+          myPython
+        ];
+      };
+    }
+  );
+}


### PR DESCRIPTION
The most important thing in this pull request is the flake.nix file. It allows users which have nix installed to clone your repo and then run `nix develop` to enter an environment where your `arch2appimage.py` works. This also works on non-arch based distros therefor (but I did not test it much so far).

For this I needed to change the `appimagetool = os.path.join(RES_DIR, "appimagetool")` variable. Maybe you could add in your readme that users should have appimagekit installed, so no binary file needs to be shipped with this code?